### PR TITLE
Fix author's name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-    <img src="https://asciian.github.io/yomu/src/icon.png" width="100">
+    <img src="https://xtaniguchimasaya.github.io/yomu/src/icon.png" width="100">
     <h1>yomu</h1>
     <p>英和辞書付きPDF閲覧ソフト</p>
     <a href="https://travis-ci.org/ta2gch/yomu">
@@ -15,8 +15,8 @@
 
 ## インストール方法
 
-[リリースページ](https://github.com/asciian/yomu/releases)よりWindows版/macOS版/Linux版をダウンロードしてください。
-また、[ブラウザ版](https://asciian.github.io/yomu/src/pdf.js/web/viewer.html)もお使いただけます。
+[リリースページ](https://github.com/xtaniguchimasaya/yomu/releases)よりWindows版/macOS版/Linux版をダウンロードしてください。
+また、[ブラウザ版](https://xtaniguchimasaya.github.io/yomu/src/pdf.js/web/viewer.html)もお使いただけます。
 
 ### NPM版
 
@@ -24,7 +24,7 @@ npm からもインストール可能になりました。
 
 ```
 npm install -g electron
-npm install -g asciian/yomu
+npm install -g xtaniguchimasaya/yomu
 ```
 
 ## 使い方
@@ -32,11 +32,11 @@ npm install -g asciian/yomu
 調べたい英単語をドラックあるいはダブルクリックすることで、
 単語の意味を単語周辺に表示します。
 
-![screenshot](https://asciian.github.io/yomu/screenshot/Screenshot.png)
+![screenshot](https://xtaniguchimasaya.github.io/yomu/screenshot/Screenshot.png)
 
 ## 関連リンク
 
-- [yomu](http://github.com/asciian/yomu) (ホスティングサイト)
+- [yomu](http://github.com/xtaniguchimasaya/yomu) (ホスティングサイト)
 - [PDF.js](https://mozilla.github.io/pdf.js/) (PDF表示用ライブラリ)
 - [EJDict](https://github.com/kujirahand/EJDict) (パブリックドメインの英和辞書)
 


### PR DESCRIPTION
Because of old name, I cannot jump to *yomu* browser edition from `README.md`. 